### PR TITLE
Add test for Header theme toggle

### DIFF
--- a/src/__tests__/Header.test.jsx
+++ b/src/__tests__/Header.test.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import Header from '../sections/About/components/Header';
+import { MyProvider } from '../context/MyProvider';
+
+test('theme toggle button switches darkMode in localStorage', () => {
+  localStorage.setItem('darkMode', 'false');
+  const { container } = render(
+    <MyProvider>
+      <Header />
+    </MyProvider>,
+  );
+  const button = container.querySelector('.nav-menu button');
+  const before = localStorage.getItem('darkMode');
+  userEvent.click(button);
+  expect(localStorage.getItem('darkMode')).not.toBe(before);
+});

--- a/src/__tests__/MenuItem.test.jsx
+++ b/src/__tests__/MenuItem.test.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import userEvent from '@testing-library/user-event';
+import MenuItem from '../components/MenuItem';
+
+const icon = <span data-testid="icon" />;
+
+test('renders link when href is provided', () => {
+  const { container } = render(
+    <MenuItem text="Github" icon={icon} link="https://github.com" onClick={() => {}} />,
+  );
+  const anchor = container.querySelector('a');
+  expect(anchor).toHaveAttribute('href', 'https://github.com');
+});
+
+test('calls onClick handler when clicked', async () => {
+  const handleClick = jest.fn();
+  const { getByRole } = render(
+    <MenuItem text="Copy" icon={icon} onClick={handleClick} link="" />,
+  );
+  const button = getByRole('button');
+  await userEvent.click(button);
+  expect(handleClick).toHaveBeenCalled();
+});

--- a/src/__tests__/MyProvider.test.jsx
+++ b/src/__tests__/MyProvider.test.jsx
@@ -1,0 +1,19 @@
+import React, { useContext } from 'react';
+import { render } from '@testing-library/react';
+import '@testing-library/jest-dom/extend-expect';
+import { MyProvider, MyContext } from '../context/MyProvider';
+
+function Display() {
+  const { darkMode } = useContext(MyContext);
+  return <span>{darkMode ? 'dark' : 'light'}</span>;
+}
+
+test('initial darkMode state reads from localStorage', () => {
+  localStorage.setItem('darkMode', 'false');
+  const { getByText } = render(
+    <MyProvider>
+      <Display />
+    </MyProvider>,
+  );
+  expect(getByText('light')).toBeInTheDocument();
+});


### PR DESCRIPTION
## Summary
- add `Header.test.jsx` under `src/__tests__`
- verify theme toggle updates `localStorage`
- add tests for MyProvider localStorage initialization
- add tests for MenuItem behavior with links and clicks

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_683f755fd5c88329815216a230fae100